### PR TITLE
Use wiringPi SPI library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,8 @@ set(RH_RF95_RPI_SRC_FILES
 	RadioHeadRpi/RHDatagram.cpp
 	RadioHeadRpi/RHGenericDriver.h
 	RadioHeadRpi/RHGenericDriver.cpp
-	RadioHeadRpi/RHGenericSPI.h
-	RadioHeadRpi/RHGenericSPI.cpp
-	RadioHeadRpi/RHLinuxSPI.h
-	RadioHeadRpi/RHLinuxSPI.cpp
+	RadioHeadRpi/RHWirePiSPI.h
+	RadioHeadRpi/RHWirePiSPI.cpp
 #        RadioHeadRpi/RHutil/RasPi.cpp
 )
 


### PR DESCRIPTION
Compile new SPI code when using RH_RF95 on Raspberry Pi